### PR TITLE
Fix Windows line endings parsing

### DIFF
--- a/NAsciidoc.Core/NAsciidoc/Parser/Parser.cs
+++ b/NAsciidoc.Core/NAsciidoc/Parser/Parser.cs
@@ -49,7 +49,7 @@ namespace NAsciidoc.Parser
 
         public Document Parse(string content, ParserContext? context = null)
         {
-            return Parse(content.Replace("\n\r", "\n").Split('\n'), context);
+            return Parse(content.Replace("\r\n", "\n").Replace("\r", "\n").Split('\n'), context);
         }
 
         public Document Parse(IList<string> strings, ParserContext? context = null)


### PR DESCRIPTION
The new line character on Windows is `\r\n`, not `\n\r`, so without this minor change files not having Unix-like endings are not rendered correctly.